### PR TITLE
Add utf-8 encoding when open files, #14

### DIFF
--- a/cochar/__init__.py
+++ b/cochar/__init__.py
@@ -58,7 +58,9 @@ VALUE_MATRIX = {
     "damage_bonus": ["-2", "-1", "0", "+1K4", "+1K6", "+2K6", "+3K6", "+4K6", "+5K6"],
 }
 
-with open(os.path.join(_THIS_FOLDER, "data", "occupations.json"), "r") as json_file:
+with open(
+    os.path.join(_THIS_FOLDER, "data", "occupations.json"), "r", encoding="utf-8"
+) as json_file:
     # Full data of occupations
     OCCUPATIONS_DATA: Dict[str, dict] = dict(json.load(json_file))
     # Just occupations names in the list
@@ -72,7 +74,9 @@ with open(os.path.join(_THIS_FOLDER, "data", "occupations.json"), "r") as json_f
         [key for key, value in OCCUPATIONS_DATA.items() if "edustr" in value["groups"]],
     ]
 
-with open(os.path.join(_THIS_FOLDER, "data", "settings.json"), "r") as json_file:
+with open(
+    os.path.join(_THIS_FOLDER, "data", "settings.json"), "r", encoding="utf-8"
+) as json_file:
     settings: dict = json.load(json_file)
     MIN_AGE: int = settings["min_age"]
     MAX_AGE: int = settings["max_age"]

--- a/cochar/cochar.py
+++ b/cochar/cochar.py
@@ -168,7 +168,7 @@ def generate_age(year, sex, age: int = False) -> int:
 
     file_name = f"pop{corrected_year}"
 
-    with open(cochar.POP_PYRAMID_PATH) as json_file:
+    with open(cochar.POP_PYRAMID_PATH, "r", encoding="utf-8") as json_file:
         age_population = cochar.utils.AGE_RANGE
         age_weights = json.load(json_file)[file_name][sex][3:-1]
         age_range = random.choices(age_population, weights=age_weights)[0]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
 
-with open(f"{THIS_FOLDER}/docs/readme.md", "r") as fh:
+with open(f"{THIS_FOLDER}/docs/readme.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(

--- a/webapp/webapp.py
+++ b/webapp/webapp.py
@@ -8,7 +8,7 @@ from flask_restful import Api, Resource, reqparse
 _THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
 _README = os.path.abspath(os.path.join(_THIS_FOLDER, "static", "README.md"))
 
-with open(_README, "r") as readme:
+with open(_README, "r", encoding="utf-8") as readme:
     text = readme.read()
     html = markdown.markdown(text)
 


### PR DESCRIPTION
This should fix the issue with broken tests
on Windows.

Although probably broken test were due to encoding issues in rname module.