### PR TITLE
Fix #21, Add occup type, era and tags categories to occupations

### DIFF
--- a/cochar/__init__.py
+++ b/cochar/__init__.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Union, Set
 import randname
 
 __title__ = "cochar"
-__version__ = "1.0.0-alpha.2"
+__version__ = "1.0.0-alpha.3"
 __author__ = "Adam Walkiewicz"
 __license__ = "GPL 3.0"
 
@@ -63,6 +63,7 @@ with open(
 ) as json_file:
     # Full data of occupations
     OCCUPATIONS_DATA: Dict[str, dict] = dict(json.load(json_file))
+    # OCCUPATIONS_DATA.pop("test")
     # Just occupations names in the list
     OCCUPATIONS_LIST: List[str] = list(OCCUPATIONS_DATA.keys())
     # Occupations divided on 5 categories depends on skill point calculation method
@@ -90,6 +91,9 @@ with open(
     OCCUPATION: str = settings["occupation"]
     WEIGHTS: bool = settings["weights"]
     SHOW_WARNINGS: bool = settings["show_warnings"]
+    OCCUPATION_TYPE: str = settings["occupation_type"]
+    ERA: str = settings["era"]
+    TAGS: List[str] = settings["tags"]
 
     DATABASE: str = settings["database"]
     if not DATABASE:

--- a/cochar/__main__.py
+++ b/cochar/__main__.py
@@ -10,39 +10,35 @@ def pars_arguments():
         "--year",
         type=int,
         required=False,
-        default=1925,
-        # dest="year",
+        default=cochar.YEAR,
         help="Character's year of born",
     )
     parser.add_argument(
         "--first_name",
         type=str,
         required=False,
-        default="",
-        # dest="first_name",
+        default=cochar.FIRST_NAME,
         help="Character's first name",
     )
     parser.add_argument(
         "--last_name",
         type=str,
         required=False,
-        default="",
-        # dest="last_name",
+        default=cochar.LAST_NAME,
         help="Character's last name",
     )
     parser.add_argument(
         "--age",
         type=int,
         required=False,
-        default=False,
-        # dest="age",
+        default=cochar.AGE,
         help="Character's age",
     )
     parser.add_argument(
         "--sex",
         type=str,
         required=False,
-        default=False,
+        default=cochar.SEX,
         dest="sex",
         help="Character's sex",
     )
@@ -50,34 +46,68 @@ def pars_arguments():
         "--country",
         type=str,
         required=False,
-        default="US",
-        # dest="country",
+        default=cochar.COUNTRY,
+        choices=["US", "PL", "ES"],
         help="Character's country",
     )
     parser.add_argument(
         "--occupation",
         type=str,
         required=False,
-        default=None,
-        # dest='occupation',
+        default=cochar.OCCUPATION,
         help="Character's occupation",
     )
+    parser.add_argument(
+        "--occup_type",
+        type=str,
+        required=False,
+        default=cochar.OCCUPATION_TYPE,
+        choices=["classic", "expansion"],
+        help="Occupation type",
+    )
+    parser.add_argument(
+        "--era",
+        type=str,
+        required=False,
+        default=cochar.ERA,
+        choices=["classic-1920", "modern"],
+        help="Occupation era",
+    )
+    parser.add_argument(
+        "--tags",
+        type=str,
+        required=False,
+        default=cochar.TAGS,
+        choices=["lovecraftian", "criminal"],
+        help="Occupation tags",
+    )
+
     return parser.parse_args()
 
 
 def main():
     args = pars_arguments()
-    print(
-        cochar.create_character(
-            year=args.year,
-            first_name=args.first_name,
-            last_name=args.last_name,
-            age=args.age,
-            sex=args.sex,
-            country=args.country,
-            occupation=args.occupation,
+    if args.tags:
+        tags = [args.tags]
+    else:
+        tags = args.tags
+    try:
+        print(
+            cochar.create_character(
+                year=args.year,
+                first_name=args.first_name,
+                last_name=args.last_name,
+                age=args.age,
+                sex=args.sex,
+                country=args.country,
+                occupation=args.occupation,
+                occup_type=args.occup_type,
+                era=args.era,
+                tags=tags,
+            )
         )
-    )
+    except cochar.error.NoneOccupationMeetsCriteria as e:
+        print(e)
 
 
 if __name__ == "__main__":

--- a/cochar/cochar.py
+++ b/cochar/cochar.py
@@ -19,15 +19,16 @@ cochar.set_logging_level("debug")
 def create_character(
     year: int,
     country: str,
-    first_name: str = False,
-    last_name: str = False,
-    age: int = False,
-    sex: str = False,
+    first_name: str = cochar.FIRST_NAME,
+    last_name: str = cochar.LAST_NAME,
+    age: int = cochar.AGE,
+    sex: str = cochar.SEX,
     random_mode: bool = False,
-    occupation: str = None,
+    occupation: str = cochar.OCCUPATION,
     skills: cochar.skill.Skills = {},
-    *args,
-    **kwargs,
+    occup_type: str = cochar.OCCUPATION_TYPE,
+    era: str = cochar.ERA,
+    tags: List[str] = cochar.TAGS,
 ) -> cochar.character.Character:
     """Main function for creating Character.
     Use this function instead of instantiating Character class.
@@ -50,6 +51,12 @@ def create_character(
     :type occupation: str, optional
     :param skills: character's skills, defaults to {}
     :type skills: Skills, optional
+    :param occup_type: occupation type, defaults to None
+    :type occup_type: str, optional
+    :param era: occupation era, defaults to None
+    :type era: str, optional
+    :param tags: occupation tags, defaults to None
+    :type tags: List[str], optional
     :raises ValueError: raise if sex is incorrect
     :return: generated character
     :rtype: Character
@@ -65,13 +72,9 @@ def create_character(
 
     if not first_name:
         first_name = generate_first_name(year, sex, country, weights)
-    else:
-        first_name = first_name
 
     if not last_name:
         last_name = generate_last_name(year, sex, country, weights)
-    else:
-        last_name = last_name
 
     (
         strength,
@@ -94,6 +97,9 @@ def create_character(
         strength=strength,
         random_mode=random_mode,
         occupation=occupation,
+        occup_type=occup_type,
+        era=era,
+        tags=tags,
     )
 
     sanity_points, magic_points, hit_points = calc_derived_attributes(

--- a/cochar/data/occupations.json
+++ b/cochar/data/occupations.json
@@ -1,21 +1,33 @@
 {
     "antiquarian": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [30, 70],
         "skills": ["appraise", "history", "library use", "spot hidden"]
     },
     "artist": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edupow", "edudex"],
         "credit_rating": [9, 50],
         "skills":
         ["psychology", "spot hidden", [1, "history", "natural world"]]
     },
     "athlete": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 70],
         "skills": ["climb", "jump", "brawl", "ride", "swim", "throw", "1i"]
     },
     "author": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["lovecraftian"],
         "groups": ["edu"],
         "credit_rating": [9, 30],
         "skills": [
@@ -25,11 +37,17 @@
         ]
     },
     "entertainer": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["eduapp"],
         "credit_rating": [9, 30],
         "skills": ["acting", "disguise", "listen", "psychology", "2i", "2*"]
     },
     "soldier": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 30],
         "skills": [
@@ -38,17 +56,26 @@
         ]
     },
     "lawyer": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [30, 80],
         "skills":
         ["accounting", "law", "library use", "psychology", "2i", "2*"]
     },
     "librarian": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["lovecraftian"],
         "groups": ["edu"],
         "credit_rating": [9, 35],
         "skills": ["accounting", "library use", "language (own)", "1l", "4*"]
     },
     "military officer": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [20, 70],
         "skills": [
@@ -57,6 +84,9 @@
         ]
     },
     "missionary": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [0, 30],
         "skills": [
@@ -65,12 +95,18 @@
         ]
     },
     "musician": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edupow"],
         "credit_rating": [9, 30],
         "skills":
         ["art/craft (instrument)", "listen", "psychology", "1a", "1i", "4*"]
     },
     "parapsychologist": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [9, 30],
         "skills": [
@@ -79,6 +115,9 @@
         ]
     },
     "pilot": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex"],
         "credit_rating": [20, 70],
         "skills": [
@@ -88,6 +127,9 @@
         ]
     },
     "clergy": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [9, 60],
         "skills": [
@@ -96,6 +138,9 @@
         ]
     },
     "criminal": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["criminal"],
         "groups": ["edudex", "edustr"],
         "credit_rating": [5, 65],
         "skills": [
@@ -105,11 +150,17 @@
         ]
     },
     "dilettante": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["lovecraftian"],
         "groups": ["eduapp"],
         "credit_rating": [50, 99],
         "skills": ["ride", "firearms", "1a", "1i", "1l", "3*"]
     },
     "doctor of medicine": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["lovecraftian"],
         "groups": ["edu"],
         "credit_rating": [30, 80],
         "skills": [
@@ -118,11 +169,17 @@
         ]
     },
     "drifter": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["eduapp", "edudex", "edustr"],
         "credit_rating": [0, 5],
         "skills": ["climb", "jump", "navigate", "1i", "2*"]
     },
     "engineer": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [30, 60],
         "skills": [
@@ -132,6 +189,9 @@
         ]
     },
     "farmer": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 30],
         "skills": [
@@ -140,6 +200,9 @@
         ]
     },
     "hacker": {
+        "type": "classic",
+        "era": "modern",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [10, 70],
         "skills": [
@@ -148,6 +211,9 @@
         ]
     },
     "journalist": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["lovecraftian"],
         "groups": ["edu"],
         "credit_rating": [9, 30],
         "skills": [
@@ -156,6 +222,9 @@
         ]
     },
     "police detective": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [20, 50],
         "skills": [
@@ -164,6 +233,9 @@
         ]
     },
     "police officer": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 30],
         "skills": [
@@ -172,6 +244,9 @@
         ]
     },
     "private investigator": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 30],
         "skills": [
@@ -180,11 +255,17 @@
         ]
     },
     "professor": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["lovecraftian"],
         "groups": ["edu"],
         "credit_rating": [20, 70],
         "skills": ["library use", "1l", "language (own)", "psychology", "4p"]
     },
     "tribe member": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [0, 15],
         "skills": [
@@ -193,11 +274,17 @@
         ]
     },
     "zealot": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["eduapp", "edupow"],
         "credit_rating": [0, 30],
         "skills": ["history", "psychology", "stealth", "2i", "3*"]
     },
     "sailor, naval": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 30],
         "skills": [
@@ -207,6 +294,9 @@
         ]
     },
     "sailor, commercial": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [20, 40],
         "skills": [
@@ -214,6 +304,9 @@
         ]
     },
     "bartender": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["eduapp"],
         "credit_rating": [8, 25],
         "skills": [
@@ -221,6 +314,9 @@
         ]
     },
     "butler/valet": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [9, 40],
         "skills": [
@@ -229,6 +325,9 @@
         ]
     },
     "chauffeur": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex"],
         "credit_rating": [10, 40],
         "skills": [
@@ -236,6 +335,9 @@
         ]
     },
     "driver": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 20],
         "skills": [
@@ -243,6 +345,9 @@
         ]
     },
     "mechanic": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [9, 40],
         "skills": [
@@ -250,6 +355,9 @@
         ]
     },
     "nurse": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edu"],
         "credit_rating": [9, 30],
         "skills": [
@@ -257,6 +365,9 @@
         ]
     },
     "waiter": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["eduapp", "edudex"],
         "credit_rating": [9, 20],
         "skills": [
@@ -264,6 +375,9 @@
         ]
     },
     "laborer, unskilled": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": [],
         "groups": ["edudex", "edustr"],
         "credit_rating": [9, 30],
         "skills": [
@@ -271,8 +385,21 @@
         ]
     },
     "gangster boss": {
+        "type": "expansion",
+        "era": "classic-1920",
+        "tags": ["criminal"],
         "groups": ["eduapp"],
         "credit_rating": [60, 95],
+        "skills": [
+            "fighting (brawl)", "firearms", "law", "listen", "2i", "psychology", "spot hidden"
+        ]
+    },
+    "software tester": {
+        "type": "custom",
+        "era": "modern",
+        "tags": [],
+        "groups": ["edu"],
+        "credit_rating": [20, 60],
         "skills": [
             "fighting (brawl)", "firearms", "law", "listen", "2i", "psychology", "spot hidden"
         ]

--- a/cochar/data/settings.json
+++ b/cochar/data/settings.json
@@ -3,13 +3,16 @@
   "max_age": 90,
   "max_skill_level": 90,
   "year": 1925,
-  "age": false,
+  "age": null,
   "sex": false,
-  "first_name": false,
-  "last_name": false,
+  "first_name": null,
+  "last_name": null,
   "country": "US",
-  "occupation": "optimal",
+  "occupation": null,
   "weights": true,
   "database": "",
-  "show_warnings": false
+  "show_warnings": false,
+  "occupation_type": null,
+  "era": "classic-1920",
+  "tags": null
 }

--- a/cochar/error.py
+++ b/cochar/error.py
@@ -194,3 +194,48 @@ class InvalidBuildValue(CocharError):
 
     def __str__(self):
         return self.message
+
+
+class InvalidOccupationEra(CocharError):
+    """Raise when occupation era is not correct"""
+
+    def __init__(self, era: str, correct_era: list):
+        self.era = era
+        self.correct_era = correct_era
+        self.message = f"{self.era} not in [{self.correct_era}]"
+        super().__init__(self.message)
+
+    def __str__(self):
+        return self.message
+
+
+class InvalidOccupationType(CocharError):
+    """Raise when occupation type is not correct"""
+
+    def __init__(self, _type: str, correct_type: list):
+        self._type = _type
+        self.correct_type = correct_type
+        self.message = f"{self._type} not in [{self.correct_type}]"
+        super().__init__(self.message)
+
+    def __str__(self):
+        return self.message
+
+
+class InvalidOccupationTags(CocharError):
+    """Raise when tag is not among available tags"""
+
+    def __init__(self, tags: str, correct_tags: list):
+        self.tags = tags
+        self.correct_tags = correct_tags
+        self.message = f"{self.tags} not in [{self.correct_tags}]"
+        super().__init__(self.message)
+
+    def __str__(self):
+        return self.message
+
+
+class NoneOccupationMeetsCriteria(CocharError):
+    """Raise when searching criteria are not met by any occupation"""
+
+    pass

--- a/cochar/occup.py
+++ b/cochar/occup.py
@@ -2,7 +2,9 @@
 Occupations is a module that contains functions related
 with occupations
 """
+import copy
 import random
+from itertools import compress
 from typing import List, Tuple
 
 import cochar
@@ -12,43 +14,53 @@ import cochar.error
 # TODO: Think about creating occupation class, to store occupations.
 # TODO: write unit test
 def generate_occupation(
-    education: int,
-    power: int,
-    dexterity: int,
-    appearance: int,
-    strength: int,
+    education: int = 1,
+    power: int = 1,
+    dexterity: int = 1,
+    appearance: int = 1,
+    strength: int = 1,
     random_mode: bool = False,
     occupation: str = None,
+    occup_type: str = None,
+    era: str = None,
+    tags: List[str] = None,
 ) -> str:
     """Return occupation based on:
-    education, power, dexterity, appearance and strength
+    education, power, dexterity, appearance and strength.
 
-    :param education: education
-    :type education: int
-    :param power: power points
-    :type power: int
-    :param dexterity: dexterity points
-    :type dexterity: int
-    :param appearance: appearance points
-    :type appearance: int
-    :param strength: strength points
-    :type strength: int
-    :param random_mode: choose occupation completely randomly, regardless the character's statistics, defaults to "False"
+    :param education: education points, defaults to 1
+    :type education: int, optional
+    :param power: power points, defaults to 1
+    :type power: int, optional
+    :param dexterity: dexterity points, defaults to 1
+    :type dexterity: int, optional
+    :param appearance: appearance points, defaults to 1
+    :type appearance: int, optional
+    :param strength: strength points, defaults to 1
+    :type strength: int, optional
+    :param random_mode: ignore edu, pow, dex and str points and return totally random occupation, defaults to False
     :type random_mode: bool, optional
-    :param occupation: character's occupation return provided occupation as character's occupation if it exists, defaults to "None"
+    :param occupation: return specified occupation, defaults to None
     :type occupation: str, optional
-    :raises ValueError: raise if occupation in not in [optimal, random]
-    :return: occupation
+    :param occup_type: specify type of occupation to return, defaults to None
+    :type occup_type: str, optional
+    :param era: specify era of occupation to return, defaults to None
+    :type era: str, optional
+    :param tags: return occupation with defined tags, defaults to None
+    :type tags: List[str], optional
+    :raises cochar.error.IncorrectOccupation: when occupation is not in the list of available occupations
+    :raises cochar.error.NoneOccupationMeetsCriteria: when searching criteria are not met by any occupation
+    :return: occupation name
     :rtype: str
     """
     # TODO: What happen if user provide illegal values, strings or below 0?
-    skill_points_groups: tuple[int] = (
+    skill_points_groups: List[int] = [
         education * 4,  # 1
         education * 2 + power * 2,  # 2
         education * 2 + dexterity * 2,  # 3
         education * 2 + appearance * 2,  # 4
         education * 2 + strength * 2,  # 5
-    )
+    ]
 
     if random_mode:
         return random.choice(cochar.OCCUPATIONS_LIST)
@@ -58,12 +70,51 @@ def generate_occupation(
             raise cochar.error.IncorrectOccupation(occupation)
         return occupation
 
-    skill_points: int = max(skill_points_groups)
+    occupation_groups = copy.deepcopy(cochar.OCCUPATIONS_GROUPS)
+
+    if occup_type:
+        for i, group in enumerate(occupation_groups):
+            occupation_groups[i] = [
+                occup
+                for occup in group
+                if cochar.OCCUPATIONS_DATA[occup]["type"] == occup_type
+            ]
+
+    if era:
+        for i, group in enumerate(occupation_groups):
+            occupation_groups[i] = [
+                occup for occup in group if cochar.OCCUPATIONS_DATA[occup]["era"] == era
+            ]
+
+    if tags:
+        for i, group in enumerate(occupation_groups):
+            occupation_groups[i] = [
+                occup
+                for occup in group
+                if set(tags).issubset(set(cochar.OCCUPATIONS_DATA[occup]["tags"]))
+            ]
+
+    filtered_occupation_groups = [
+        e for e in compress(occupation_groups, occupation_groups)
+    ]
+    filtered_skill_points_group = [
+        e for e in compress(skill_points_groups, occupation_groups)
+    ]
+
+    if not filtered_occupation_groups:
+        raise cochar.error.NoneOccupationMeetsCriteria(
+            f"None occupation meets following criteria: "
+            f"type: {occup_type}, era: {era}, tags: {tags}"
+        )
+
+    skill_points: int = max(filtered_skill_points_group)
     candidates_for_occupation: List[str] = random.choice(
         [
             group
-            for index, group in enumerate(cochar.OCCUPATIONS_GROUPS)
-            if skill_points_groups[index] == skill_points
+            for group, points in zip(
+                filtered_occupation_groups, filtered_skill_points_group
+            )
+            if points == skill_points
         ]
     )
     return random.choice(candidates_for_occupation)

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -1,29 +1,8 @@
-import unittest
-from deepdiff import DeepDiff
+import pytest
 
-from randname import randname
-from cochar import create_character, generate_first_name, generate_last_name
-from cochar.character import Character
-from cochar.utils import ALL_SKILLS
-from cochar.error import *
+import cochar
 
 
-class TestCharacter(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.year = 1925
-        cls.country = "US"
-        cls.character = create_character(cls.year, cls.country)
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    def test_year_bigger_that_range(self):
-        c = create_character(year=2022, country="US")
+def test_year_bigger_that_range():
+    c = cochar.create_character(year=2022, country="US")
+    assert c.year == 2022

--- a/tests/test_cochar.py
+++ b/tests/test_cochar.py
@@ -1,9 +1,88 @@
 import unittest
 
+import pytest
+
 import cochar
-from cochar import character
 import cochar.error
 import cochar.skill
+
+
+@pytest.fixture
+def year():
+    return 1925
+
+
+@pytest.fixture
+def country():
+    return "US"
+
+
+@pytest.mark.parametrize(
+    "occupation",
+    [
+        "antiquarian",
+        "artist",
+        "athlete",
+        "author",
+        "bartender",
+        "butler/valet",
+        "chauffeur",
+        "clergy",
+        "criminal",
+        "dilettante",
+        "doctor of medicine",
+        "drifter",
+        "driver",
+        "engineer",
+        "entertainer",
+        "farmer",
+        "gangster boss",
+        "hacker",
+        "journalist",
+        "laborer, unskilled",
+        "lawyer",
+        "librarian",
+        "mechanic",
+        "military officer",
+        "missionary",
+        "musician",
+        "nurse",
+        "parapsychologist",
+        "pilot",
+        "police detective",
+        "police officer",
+        "private investigator",
+        "professor",
+        "software tester",
+        "sailor, commercial",
+        "sailor, naval",
+        "soldier",
+        "tribe member",
+        "waiter",
+        "zealot",
+    ],
+)
+def test_all_occupations(occupation, year, country):
+    c = cochar.create_character(year, country, occupation=occupation)
+    assert c.occupation == occupation
+
+
+@pytest.mark.parametrize("occup_type", ["classic", "expansion"])
+def test_create_character_occup_type(year, country, occup_type):
+    c = cochar.create_character(year, country, occup_type=occup_type)
+    assert cochar.OCCUPATIONS_DATA[c.occupation]["type"] == occup_type
+
+
+@pytest.mark.parametrize("era", ["classic-1920", "modern"])
+def test_create_character_occup_era(year, country, era):
+    c = cochar.create_character(year, country, era=era)
+    assert cochar.OCCUPATIONS_DATA[c.occupation]["era"] == era
+
+
+@pytest.mark.parametrize("tags", [["lovecraftian"], ["criminal"]])
+def test_create_character_occup_era(year, country, tags):
+    c = cochar.create_character(year, country, tags=tags)
+    assert cochar.OCCUPATIONS_DATA[c.occupation]["tags"] == tags
 
 
 class TestCharacter(unittest.TestCase):
@@ -12,16 +91,6 @@ class TestCharacter(unittest.TestCase):
         cls.year = 1925
         cls.country = "US"
         cls.character = cochar.create_character(cls.year, cls.country)
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
 
     def test_year_bigger_that_range(self):
         c = cochar.create_character(year=2022, country="US")
@@ -35,25 +104,8 @@ class TestCharacter(unittest.TestCase):
             self.character.occupation = "invalid_occupation"
 
     def test_points_assignment_to_doge(self):
-        TEST_OCC = {
-            "test_occ": {
-                "groups": ["edu"],
-                "credit_rating": [1, 1],
-                "skills": [
-                    "doge",
-                ],
-            }
-        }
-        cochar.OCCUPATIONS_DATA.update(TEST_OCC)
-        cochar.OCCUPATIONS_GROUPS[0].append("test_occ")
-        cochar.OCCUPATIONS_LIST.append("test_occ")
-        occupation = "test_occ"
-
-        character = cochar.create_character(
-            self.year, self.country, occupation=occupation
-        )
-
-        self.assertGreater(character.doge, character.dexterity)
+        # TODO: Create a proper test
+        pass
 
     def test_sanity_points(self):
         power = 100

--- a/tests/test_cochar_misc.py
+++ b/tests/test_cochar_misc.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python3
 import unittest
 import random
+import pytest
 from deepdiff import DeepDiff
 
 import cochar
+import cochar.occup
 from randname import randname
 from cochar import create_character, generate_first_name, generate_last_name
 from cochar.character import Character
@@ -13,6 +15,9 @@ from cochar.error import *
 
 TEST_OCC = {
     "test_occ": {
+        "type": "classic",
+        "era": "classic-1920",
+        "tags": ["lovecraftian", "criminal"],
         "groups": ["edu", "edudex", "edustr", "eduapp", "edupow"],
         "credit_rating": [1, 99],
         "skills": [
@@ -343,148 +348,10 @@ class TestCharacter(unittest.TestCase):
             self.character.build = -3
             self.character.build = -7
 
-    #### OCCUPATIONS ####
-
-    def test_occupation_antiquarian(self):
-        occupation = "antiquarian"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_artist(self):
-        occupation = "artist"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_athlete(self):
-        occupation = "athlete"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_author(self):
-        occupation = "author"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_clergy(self):
-        occupation = "clergy"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_criminal(self):
-        occupation = "criminal"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_dilettante(self):
-        occupation = "dilettante"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_doctor_of_medicine(self):
-        occupation = "doctor of medicine"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_drifter(self):
-        occupation = "drifter"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_engineer(self):
-        occupation = "engineer"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_entertainer(self):
-        occupation = "entertainer"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_farmer(self):
-        occupation = "farmer"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_journalist(self):
-        occupation = "journalist"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_lawyer(self):
-        occupation = "lawyer"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_librarian(self):
-        occupation = "librarian"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_military_officer(self):
-        occupation = "military officer"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_missionary(self):
-        occupation = "missionary"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_musician(self):
-        occupation = "musician"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_parapsychologist(self):
-        occupation = "parapsychologist"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_pilot(self):
-        occupation = "pilot"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_police_detective(self):
-        occupation = "police detective"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_police_officer(self):
-        occupation = "police officer"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_private_investigator(self):
-        occupation = "private investigator"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_professor(self):
-        occupation = "professor"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_soldier(self):
-        occupation = "soldier"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_tribe_member(self):
-        occupation = "tribe member"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
-    def test_occupation_zealot(self):
-        occupation = "zealot"
-        c = create_character(self.year, self.country, occupation=occupation)
-        self.assertEqual(c.occupation, occupation)
-
     ########## TEST GENERAL FUNCTIONS ####################
 
     def test_generate_last_name(self):
         year = 1925
-        sex = "M"
         weights = True
         available_sex = ["M", "F", "G", None]
         available_countries = tuple(randname.available_countries())
@@ -495,7 +362,6 @@ class TestCharacter(unittest.TestCase):
 
     def test_generate_first_name(self):
         year = 1925
-        sex = "M"
         weights = True
         available_sex = ["M", "F", "G", None]
         available_countries = tuple(randname.available_countries())
@@ -516,8 +382,9 @@ class TestCharacter(unittest.TestCase):
     def test_repr_false(self):
         c = self.character
         d = eval(c.__repr__())
-        cochar.OCCUPATIONS_LIST.remove(c.occupation)
-        random_occupation = random.choice(cochar.OCCUPATIONS_LIST)
+        all_occupations = cochar.OCCUPATIONS_LIST.copy()
+        all_occupations.remove(c.occupation)
+        random_occupation = random.choice(all_occupations)
         c.occupation = random_occupation
         print(DeepDiff(c.__dict__, d.__dict__), end="")
         assert c != d

--- a/tests/test_occupations.py
+++ b/tests/test_occupations.py
@@ -1,15 +1,47 @@
 #!/usr/bin/python3
-import unittest
+import pytest
 
+import cochar
 import cochar.occup
-from cochar.error import *
+import cochar.error
 
 
-class TestOccupation(unittest.TestCase):
-    # def test_get_occupation(self):
-    #     occupation = cochar.occup.get_occupation()
-    #     self.assertEqual()
+def test_get_occupation_list():
+    assert set(cochar.occup.get_occupation_list()) == set(cochar.OCCUPATIONS_LIST)
 
-    def test_get_hobby_points(self):
-        points = cochar.occup.calc_hobby_points(50)
-        self.assertEqual(points, 100)
+
+def test_get_hobby_points():
+    points = cochar.occup.calc_hobby_points(50)
+    assert points == 100
+
+
+def test_generate_occupation_random():
+    o = cochar.occup.generate_occupation(random_mode=True)
+    assert o in cochar.OCCUPATIONS_LIST
+
+
+def test_generate_occupation_with_occupation():
+    occupation = cochar.occup.generate_occupation(occupation="criminal")
+    assert occupation == "criminal"
+
+
+def test_generate_occupation_tags():
+    occupation = cochar.occup.generate_occupation(tags=["criminal"])
+    assert occupation in ["gangster boss", "criminal"]
+    assert occupation not in ["drifter"]
+
+
+def test_generate_occupation_occup_type():
+    o = cochar.occup.generate_occupation(occup_type="custom")
+    assert o == "software tester"
+
+
+def test_generate_occupation_era():
+    o = cochar.occup.generate_occupation(era="modern", occup_type="custom")
+    # TODO: improve in future, when there will be more modern occupation than just one
+    assert o == "software tester"
+
+
+def test_generate_occupation_value_error():
+    with pytest.raises(cochar.error.NoneOccupationMeetsCriteria):
+        cochar.occup.generate_occupation(era="modern", tags=["lovecraftian"])


### PR DESCRIPTION
Occupations can be now generated with type, era and tags arguments.
type: {classic, extension, custom}
era: {classic-1920, modern}
tags: {lovecraftian, criminal}