### PR TITLE
Update api docs

### DIFF
--- a/webapp/templates/docs.html
+++ b/webapp/templates/docs.html
@@ -34,7 +34,7 @@ custom_css %}
           <div class="col">
             <span class="badge bg-success">200</span> Success
             <p>
-              <kbd>curl -X GET http://www.cochar.pl/api/v1/get</kbd>
+              <kbd>curl -X GET https://www.cochar.pl/api/v1/get</kbd>
             </p>
             <pre>
 {
@@ -91,7 +91,7 @@ custom_css %}
             <span class="badge bg-danger">400</span> Bad Request
             <p>
               <kbd
-                >curl -X GET http://www.cochar.pl/api/v1/get?year=invalid</kbd
+                >curl -X GET https://www.cochar.pl/api/v1/get?year=invalid</kbd
               >
             </p>
             <pre>
@@ -116,7 +116,7 @@ custom_css %}
             <p>
               <kbd
                 >curl -X GET
-                http://www.cochar.pl/api/v1/get?country=invalid</kbd
+                https://www.cochar.pl/api/v1/get?country=invalid</kbd
               >
             </p>
             <pre>
@@ -157,7 +157,7 @@ custom_css %}
             </p>
             <span class="badge bg-danger">400</span> Bad Request
             <p>
-              <kbd>curl -X GET http://www.cochar.pl/api/v1/get?age=14</kbd>
+              <kbd>curl -X GET https://www.cochar.pl/api/v1/get?age=14</kbd>
             </p>
             <pre>
 {
@@ -168,7 +168,7 @@ custom_css %}
 
             <span class="badge bg-danger">400</span> Bad Request
             <p>
-              <kbd>curl -X GET http://www.cochar.pl/api/v1/get?age=invalid</kbd>
+              <kbd>curl -X GET https://www.cochar.pl/api/v1/get?age=invalid</kbd>
             </p>
             <pre>
 {
@@ -186,7 +186,7 @@ custom_css %}
             <p>Choices to specify gender: "M", "F"</p>
             <span class="badge bg-danger">400</span> Bad Request
             <p>
-              <kbd>curl -X GET http://www.cochar.pl/api/v1/get?sex=invalid</kbd>
+              <kbd>curl -X GET https://www.cochar.pl/api/v1/get?sex=invalid</kbd>
             </p>
             <pre>
 {
@@ -224,7 +224,7 @@ custom_css %}
             <p>"classic-1890" is not supported</p>
             <span class="badge bg-danger">400</span> Bad Request
             <p>
-              <kbd>curl -X GET http://www.cochar.pl/api/v1/get?era=invalid</kbd>
+              <kbd>curl -X GET https://www.cochar.pl/api/v1/get?era=invalid</kbd>
             </p>
             <pre>
 {
@@ -251,7 +251,7 @@ custom_css %}
             <p>
               <kbd
                 >curl -X GET
-                http://www.cochar.pl/api/v1/get?occup_type=invalid</kbd
+                https://www.cochar.pl/api/v1/get?occup_type=invalid</kbd
               >
             </p>
             <pre>
@@ -273,7 +273,7 @@ custom_css %}
             <span class="badge bg-danger">400</span> Bad Request
             <p>
               <kbd
-                >curl -X GET http://www.cochar.pl/api/v1/get?tags=invalid</kbd
+                >curl -X GET https://www.cochar.pl/api/v1/get?tags=invalid</kbd
               >
             </p>
             <pre>
@@ -294,7 +294,7 @@ custom_css %}
             </p>
             <span class="badge bg-danger">400</span> Bad Request
             <p>
-              <kbd>curl -X GET http://www.cochar.pl/api/v1/get?occupation=invalid</kbd>
+              <kbd>curl -X GET https://www.cochar.pl/api/v1/get?occupation=invalid</kbd>
             </p>
             <pre>
 {
@@ -317,7 +317,7 @@ custom_css %}
             <span class="badge bg-danger">400</span> Bad Request
             <p>
               <kbd
-                >curl -X GET http://www.cochar.pl/api/v1/get?era=modern&tags=lovecraftian</kbd
+                >curl -X GET https://www.cochar.pl/api/v1/get?era=modern&tags=lovecraftian</kbd
               >
             </p>
             <pre>

--- a/webapp/webapp.py
+++ b/webapp/webapp.py
@@ -30,6 +30,7 @@ _README = os.path.abspath(os.path.join(_THIS_FOLDER, "static", "README.md"))
 OCCUPATIONS = cochar.occup.get_occupation_list()
 LIMITS = ["10 per second", "10000 per day"]
 
+
 def get_remote_address() -> str:
     """Get client's IP address.
     pythonanywhere.com stores original client's IP in 'X-Real-IP' header.
@@ -39,7 +40,7 @@ def get_remote_address() -> str:
     :return: client's IP address
     :rtype: str
     """
-    return request.headers.get('X-Real-IP') or request.remote_addr or "127.0.0.1"
+    return request.headers.get("X-Real-IP") or request.remote_addr or "127.0.0.1"
 
 
 with open(_README, "r", encoding="utf-8") as readme:
@@ -174,7 +175,7 @@ class GenerateCharacter(Resource):
                     "\nPlease try again later.\n"
                     "If you did not exceed the limit check if someone "
                     "else in your network is using this website"
-                    )
+                ),
             }, 429
 
 


### PR DESCRIPTION
API docs uses old `http` protocol instead of new `https` in the examples